### PR TITLE
Fix the wrong max size of EditWorkspaceDialog.

### DIFF
--- a/tools/designer/BehaviacDesigner/EditWorkspaceDialog.cs
+++ b/tools/designer/BehaviacDesigner/EditWorkspaceDialog.cs
@@ -59,8 +59,6 @@ namespace Behaviac.Design
             checkButtons();
 
             setMetaVisible(false);
-
-            this.MaximumSize = new System.Drawing.Size(int.MaxValue, 272);
         }
 
         private string _filename = string.Empty;


### PR DESCRIPTION
BehaviacDesigner 3.16.20's messed dialog:
![mess](https://cloud.githubusercontent.com/assets/63832/23328753/aef7d1e4-fb64-11e6-89f2-fdaee7d2d5dc.png)
