### PR TITLE
删除前置条件执行中无用的判断

### DIFF
--- a/src/behaviortree/behaviortree.cpp
+++ b/src/behaviortree/behaviortree.cpp
@@ -190,7 +190,7 @@ namespace behaviac {
             if (pPrecond != NULL) {
                 Precondition::EPhase ph = pPrecond->GetPhase();
 
-                if (phase == Precondition::E_BOTH || ph == Precondition::E_BOTH || ph == phase) {
+                if (ph == Precondition::E_BOTH || ph == phase) {
                     bool taskBoolean = pPrecond->Evaluate((Agent*)pAgent);
 
                     CombineResults(firstValidPrecond, lastCombineValue, pPrecond, taskBoolean);


### PR DESCRIPTION
Precondition::EPhase phase = bIsAlive ? Precondition::E_UPDATE : Precondition::E_ENTER; phase不可能为Precondition::E_BOTH