### PR TITLE
fix crash caused by BranchTask::onevent under debug version

### DIFF
--- a/src/behaviortree/behaviortree_task.cpp
+++ b/src/behaviortree/behaviortree_task.cpp
@@ -1559,7 +1559,7 @@ namespace behaviac {
                 BranchTask* parentBranch = this->m_currentTask->GetParent();
 
                 //back track the parents until the branch
-                while (parentBranch && parentBranch != this) {
+                while (parentBranch && parentBranch != this && this->m_currentTask) {
                     BEHAVIAC_ASSERT(parentBranch->GetStatus() == BT_RUNNING);
 
                     bGoOn = parentBranch->onevent(pAgent, eventName, eventParams);
@@ -1579,9 +1579,9 @@ namespace behaviac {
     }
 
     bool BranchTask::onevent(Agent* pAgent, const char* eventName, behaviac::map<uint32_t, IInstantiatedVariable*>* eventParams) {
+	bool bGoOn = true;
         if (this->m_node->HasEvents()) {
-            bool bGoOn = true;
-
+			
             if (this->m_currentTask) {
                 bGoOn = this->oneventCurrentNode(pAgent, eventName, eventParams);
             }
@@ -1591,7 +1591,7 @@ namespace behaviac {
             }
         }
 
-        return true;
+        return bGoOn;
     }
 
     bool LeafTask::onevent(Agent* pAgent, const char* eventName, behaviac::map<uint32_t, IInstantiatedVariable*>* eventParams) {


### PR DESCRIPTION
行为树处理事件时，出现崩溃。测试用例参见[地址](https://github.com/kecookier/Exercise/tree/master/behavior_ai)。

分析发现，出错流程如下：
1. `FireEvent()`之后，顺利调用任务子树的`btexec()`。由于任务子树未返回`BT_RUNNING`，任务子树执行结束。
2. 同一帧里紧接着弹出已经压栈的原行为树，并且调用`btexec()`，如果此次执行结果不是`BT_RUNNING`。那么会在`BranchTask::oneventCurrentNode`函数中触发`BEHAVIAC_ASSERT`。
```c++
//give the handling back to parents
if (bGoOn && this->m_currentTask) {
    BranchTask* parentBranch = this->m_currentTask->GetParent();

    //back track the parents until the branch
    while (parentBranch && parentBranch != this) {
        BEHAVIAC_ASSERT(parentBranch->GetStatus() == BT_RUNNING);

        bGoOn = parentBranch->onevent(pAgent, eventName, eventParams);

        if (!bGoOn) {
            return false;
        }

        parentBranch = parentBranch->GetParent();
    }
}
```