### PR TITLE
fix editor TypeVerifyWarning bug

### DIFF
--- a/tools/designer/BehaviacDesigner/MetaStoreDock.cs
+++ b/tools/designer/BehaviacDesigner/MetaStoreDock.cs
@@ -274,7 +274,16 @@ namespace Behaviac.Design
                 {
                     // refresh the meta
                     Debug.Check(Workspace.Current != null);
-                    MainWindow.Instance.SetWorkspace(Workspace.Current.FileName, false, true);
+                    if (MainWindow.Instance.SetWorkspace(Workspace.Current.FileName, false, true))
+                    {
+                        /* 
+                        'SetWorkspace' method will reload the meta file and recreate all the 'AgentType' objects(Plugin.AgentTypes),
+                        however, the '_customizedAgent' property in class 'MetaTypePanel' is still referring to the old one.
+                        So call the 'Initialize' method to refresh this reference. And maybe we can consider not recreating objects
+                        but updating properties.
+                        */
+                        this.metaTypePanel.Initialize(this.getSelectedType());
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
修复在类型信息面板中第二次修改属性提示“请为类型设置正确的名字”问题
重现方法：
1、打开类型信息面板后编辑任意类型的显示名或描述属性并点应用；
2、第二次编辑相同类的显示名或描述属性并点应用，此时即弹出“请为类型设置正确的名字”提示。
调试发现：每次修改属性时会重新加载一次meta数据，以及重新创建所有AgentTypes对象（MainWindow中的SetWorkspace方法，Plugin._agentTypes），虽然在MetaStoreDock类的editType方法中有设置选择项（会触发一次所选项改变，之后MetaTypePanel会重新Initialize），但重建的逻辑（save）是在设置选择项之后。这就导致MetaTypePanel中的_customizedAgent成员引用的还是旧的AgentTypes对象，于是第二次修改时Verify不过（_customizedAgent != agent，agent.Name == fullname）弹出了这个提示。

```cs
foreach (AgentType agent in Plugin.AgentTypes)
{
    if (this.GetMetaType() == MetaTypes.Agent && _customizedAgent == agent)
    {
        return true;
    }

    if (agent.Name == fullname)
    {
        return false;
    }
}
```

另外发现命名空间和类名按照上面的步骤操作时会出现显示的命名空间和类名是第一次修改的名字，原因和上面的情况一样，之所以不会出现提示是因为fullname和agent.Name并不一致所以不会返回false。
