### PR TITLE
Fix wait node bug(C#)

### DIFF
--- a/tools/designer/Plugins/PluginBehaviac/NodeExporters/Cs/Actions/WaitCsExporter.cs
+++ b/tools/designer/Plugins/PluginBehaviac/NodeExporters/Cs/Actions/WaitCsExporter.cs
@@ -78,7 +78,9 @@ namespace PluginBehaviac.NodeExporters
 
             if (wait.Time != null)
             {
-                stream.WriteLine("{0}\t\tprotected override double GetTime(Agent pAgent)", indent);
+                string strMethod = "{0}\t\tprotected override " + (Workspace.Current.UseIntValue ? "int GetIntTime(Agent pAgent)" : "double GetTime(Agent pAgent)");
+                stream.WriteLine(strMethod, indent);
+
                 stream.WriteLine("{0}\t\t{{", indent);
 
                 string retStr = RightValueCsExporter.GenerateCode(node, wait.Time, stream, indent + "\t\t\t", string.Empty, string.Empty, "Time");


### PR DESCRIPTION
#36 
工作区使用整数值时，等待节点导出的cs代码重写GetIntTime，修复等待节点无效问题