### PR TITLE
bool vector operator [] crash

### DIFF
--- a/inc/behaviac/agent/agent.h
+++ b/inc/behaviac/agent/agent.h
@@ -651,6 +651,11 @@ namespace behaviac {
         void set(bool v) {
             behaviac::THREAD_ID_TYPE threadId = behaviac::GetTID();
             bool* value = m_threadInt.find((long)threadId);
+            if (!value)
+            {
+                m_threadInt.add((long)threadId, v);
+                return;
+            }
             BEHAVIAC_ASSERT(value);
             *value = v;
         }


### PR DESCRIPTION
**
![image](https://user-images.githubusercontent.com/11240104/62922391-cb018b00-bd9a-11e9-8951-22b33b7dfb00.png)
**
![image](https://user-images.githubusercontent.com/11240104/62922461-eec4d100-bd9a-11e9-870e-769d370b5f88.png)
****

bool数组索引的Get操作实现会调用ThreadBool::set
![image](https://user-images.githubusercontent.com/11240104/62923562-8d523180-bd9d-11e9-9ba6-5d286c350618.png)

![image](https://user-images.githubusercontent.com/11240104/62923688-cf7b7300-bd9d-11e9-8ce7-b9fc99c0a654.png)

然而没有地方调用m_threadInt.add，所以必然会在断言BEHAVIAC_ASSERT(value)处crash