### PR TITLE
[bugfix] 如果系统没有zh_CN.utf8，则hotUpdate会不工作。修改MBSToWCS如果setlocale失败，则使用默…

### DIFF
--- a/src/common/string/stringutils.cpp
+++ b/src/common/string/stringutils.cpp
@@ -52,8 +52,9 @@ namespace behaviac {
 
                 char* loc = setlocale(LC_ALL, locale);
 
+                // if loc==null, use default charset
+                mbstowcs(buffer, str.c_str(), dwNum);
                 if (loc) {
-                    mbstowcs(buffer, str.c_str(), dwNum);
                     ret = true;
                 }
 
@@ -108,8 +109,9 @@ namespace behaviac {
 
                 char* loc = setlocale(LC_ALL, locale);
 
+                // if loc==null, use default charset
+                wcstombs(buffer, wstr.c_str(), dwNum);
                 if (loc) {
-                    wcstombs(buffer, wstr.c_str(), dwNum);
                     ret = true;
                 }
 


### PR DESCRIPTION
…认的字符集转换。