### PR TITLE
1. 修复 tree exec stack 在切换agent时数据错乱问题

### DIFF
--- a/tools/designer/BehaviacDesigner/CallStackDock.Designer.cs
+++ b/tools/designer/BehaviacDesigner/CallStackDock.Designer.cs
@@ -114,6 +114,7 @@ namespace Behaviac.Design
 
         #endregion
 
+        private string preAgengName = "";
         private System.Windows.Forms.ListBox callstackListBox;
         private System.Windows.Forms.ContextMenuStrip contextMenu;
         private System.Windows.Forms.ToolStripMenuItem copyMenuItem;


### PR DESCRIPTION
        1.1 先运行agent,  后打开 stack窗口, 数据为空
        1.2 先打开stack窗口, 后切换agent, 旧数据残留